### PR TITLE
Removing deprecated Config::getSettings()

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -12,7 +12,7 @@ prettify = (editor, sorted) ->
     )
 
 formatter = (text, sorted) ->
-  editorSettings = atom.config.getSettings().editor
+  editorSettings = atom.config.get('editor')
   if editorSettings.softTabs?
     space = Array(editorSettings.tabLength + 1).join(" ")
   else


### PR DESCRIPTION
Atom's API has deprecated `Config::getSettings()` in favor of `Config::get()`. 

In recent versions of Atom, `atom.config.getSettings().editor` doesn't return the right editor config, so variables like `tabLength` don't reflect the current settings. `atom.config.get('editor')` returns the correct settings.