### PR TITLE
Allow notification on parse errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 Pretty JSON
 ===========
 
-[Atom](http://atom.io/) plugin. Format JSON documents.
+[Atom](http://atom.io/) plugin to format JSON documents.
 
 ![](http://i.imgur.com/Nd4GvtP.gif)
 
-Just select the text to format and select the prettify command. In a JSON file, it formats the whole file.
+Select the text to format and then execute the Pretty JSON `prettify` command. For JSON files, format the entire file automatically without need to first select the text. Minify and sorting commands are available too.
+
+This plugin will post a notification to Atom if there is a parse error in the JSON. Disable warnings in this plugin's settings panel if you do not desire this feature.
+
+To proactively avoid JSON errors, consider using a linter for JSON, such as the delightful [linter-jsonlint](https://atom.io/packages/linter-jsonlint).

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,5 @@
-stringify = require("json-stable-stringify")
-uglify = require("jsonminify")
+stringify = require 'json-stable-stringify'
+uglify = require 'jsonminify'
 formatter = {}
 
 prettify = (editor, sorted) ->
@@ -7,10 +7,10 @@ prettify = (editor, sorted) ->
 
   if wholeFile
     text = editor.getText()
-    editor.setText(formatter.pretty(text, sorted))
+    editor.setText formatter.pretty(text, sorted)
   else
     text = editor.replaceSelectedText({}, (text) ->
-      formatter.pretty(text, sorted)
+      formatter.pretty text, sorted
     )
 
 minify = (editor, sorted) ->
@@ -18,44 +18,53 @@ minify = (editor, sorted) ->
 
   if wholeFile
     text = editor.getText()
-    editor.setText(formatter.minify(text))
+    editor.setText formatter.minify(text)
   else
     text = editor.replaceSelectedText({}, (text) ->
-      formatter.minify(text);
+      formatter.minify text
     )
 
 formatter.pretty = (text, sorted) ->
-  editorSettings = atom.config.get('editor')
+  editorSettings = atom.config.get 'editor'
   if editorSettings.softTabs?
-    space = Array(editorSettings.tabLength + 1).join(" ")
+    space = Array(editorSettings.tabLength + 1).join ' '
   else
-    space = "\t"
+    space = '\t'
 
   try
     parsed = JSON.parse(text)
     if sorted
-      return stringify(parsed, { space: space })
+      return stringify parsed,
+        space: space
     else
-      return JSON.stringify(parsed, null, space)
+      return JSON.stringify parsed, null, space
   catch error
+    if atom.config.get 'pretty-json.notifyOnParseError'
+      atom.notifications.addWarning "JSON Pretty parse issue: #{error}"
     text
 
 formatter.minify = (text) ->
   try
-    JSON.parse(text)
-    uglify(text);
+    JSON.parse text
+    uglify text
   catch error
-    text;
+    if atom.config.get 'pretty-json.notifyOnParseError'
+      atom.notifications.addWarning "JSON Pretty parse issue: #{error}"
+    text
 
 module.exports =
+  config:
+    notifyOnParseError:
+      type: 'boolean'
+      default: true
   activate: ->
     atom.commands.add 'atom-workspace',
       'pretty-json:prettify': ->
         editor = atom.workspace.getActiveTextEditor()
-        prettify(editor)
+        prettify editor
       'pretty-json:sort-and-prettify': ->
         editor = atom.workspace.getActiveTextEditor()
-        prettify(editor, true)
+        prettify editor, true
       'pretty-json:minify': ->
         editor = atom.workspace.getActiveTextEditor()
-        minify(editor, true)
+        minify editor, true

--- a/menus/pretty-json.cson
+++ b/menus/pretty-json.cson
@@ -10,6 +10,10 @@
       {
         'label': 'Minify'
         'command': 'pretty-json:minify'
+      },
+      {
+        'label': 'Sort and Prettify'
+        'command': 'pretty-json:sort-and-prettify'
       }
     ]
   ]


### PR DESCRIPTION
- Resolves some coffeescript style issues. Such as removes unnecessary
  `;`, `()`, and uses single quotes for string literals.
- Adds `atom.notifications` code to error catch code.
- Adds `notifyOnParseError` configuration option, default to `true`.
- Updates README.md with additional feature information.
- Adds missing "Sort and Prettify" menu command.

This should resolve #29 as a lot of the confusion about this package not
working is likely due to parse issues.