### PR TITLE
Honor language specific settings.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,18 +1,19 @@
 formatter = {}
 
-formatter.space = ->
-  editorSettings = atom.config.get 'editor'
-  if editorSettings.softTabs?
-    return Array(editorSettings.tabLength + 1).join ' '
+formatter.space = (scope) ->
+  softTabs = [atom.config.get 'editor.softTabs', scope: scope]
+  tabLength = Number([atom.config.get 'editor.tabLength', scope: scope])
+  if softTabs?
+    return Array(tabLength + 1).join ' '
   else
     return '\t'
 
-formatter.stringify = (obj, sorted) ->
+formatter.stringify = (obj, scope, sorted) ->
   # lazy load requirements
   JSONbig = require 'json-bigint'
   stringify = require 'json-stable-stringify'
 
-  space = formatter.space()
+  space = formatter.space scope
   if sorted
     return stringify obj,
       space: space
@@ -28,12 +29,12 @@ formatter.parseAndValidate = (text) ->
       atom.notifications.addWarning "JSON Pretty: #{error.name}: #{error.message} at character #{error.at} near \"#{error.text}\""
     throw error
 
-formatter.pretty = (text, sorted) ->
+formatter.pretty = (text, scope, sorted) ->
   try
     parsed = formatter.parseAndValidate text
   catch error
     return text
-  return formatter.stringify parsed, sorted
+  return formatter.stringify parsed, scope, sorted
 
 formatter.minify = (text) ->
   try
@@ -43,7 +44,7 @@ formatter.minify = (text) ->
   uglify = require 'jsonminify' # lazy load requirements
   return uglify text
 
-formatter.jsonify = (text, sorted) ->
+formatter.jsonify = (text, scope, sorted) ->
   vm = require 'vm' # lazy load requirements
   try
     vm.runInThisContext("newObject = #{text};")
@@ -51,7 +52,7 @@ formatter.jsonify = (text, sorted) ->
     if atom.config.get 'pretty-json.notifyOnParseError'
       atom.notifications.addWarning "#{packageName}: eval issue: #{error}"
     return text
-  return formatter.stringify newObject, sorted
+  return formatter.stringify newObject, scope, sorted
 
 formatter.doEntireFile = (editor) ->
   grammars = atom.config.get('pretty-json.grammars') ? []
@@ -68,9 +69,9 @@ PrettyJSON =
 
   prettify: (editor, sorted) ->
     if formatter.doEntireFile editor
-      editor.setText formatter.pretty(editor.getText(), sorted)
+      editor.setText formatter.pretty(editor.getText(), editor.getRootScopeDescriptor(), sorted)
     else
-      editor.replaceSelectedText({}, (text) -> formatter.pretty text, sorted)
+      editor.replaceSelectedText({}, (text) -> formatter.pretty text, ['source.json'], sorted)
 
   minify: (editor) ->
     if formatter.doEntireFile editor
@@ -80,9 +81,9 @@ PrettyJSON =
 
   jsonify: (editor, sorted) ->
     if formatter.doEntireFile editor
-      editor.setText formatter.jsonify(editor.getText(), sorted)
+      editor.setText formatter.jsonify(editor.getText(), editor.getRootScopeDescriptor(), sorted)
     else
-      editor.replaceSelectedText({}, (text) -> formatter.jsonify text)
+      editor.replaceSelectedText({}, (text) -> formatter.jsonify text['source.json'], sorted)
 
   activate: ->
     atom.commands.add 'atom-workspace',


### PR DESCRIPTION
When formatting an entire file, use the file's scope when determining
what values to use for softTabs and tabLength. When formatting selected
text within a file, default to the `source.json` scope if available.
In either case, always fallback to the editor defaults when language
specific settings are not available.

Should resolve #36.